### PR TITLE
Allow to order entities by id or type

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-browser" version="3.0.0a1">
+<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-browser" version="3.0.0a2">
     <details>
         <title>NGSI browser</title>
         <email>wirecloud@conwet.com</email>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -2,6 +2,8 @@
 
 - Use normalized payloads for entities, allowing to update attribute type and
   its metadata.
+- Allow to order entities by id or type (requires support from the ontext broker
+    server, e.g. orion v0.12.0 or higher)
 
 
 ## v2.0.1 (2018-03-20)

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -209,7 +209,7 @@
                         }
                     }
                     if (options.order && options.order.length > 0) {
-                        orderBy = options.order.map((field) => {return field[0].replace(/^-/, "!");}).join(',');
+                        orderBy = options.order.map((field) => {return field.replace(/^-/, "!");}).join(',');
                     }
 
                     this.ngsi_connection.v2.listEntities({
@@ -247,17 +247,17 @@
 
         // Create the table
         fields = [
-            {field: 'id', label: 'Id', sortable: false}
+            {field: 'id', label: 'Id', sortable: true}
         ];
         if (mp.prefs.get('type_column')) {
-            fields.push({field: 'type', label: 'Type', sortable: false});
+            fields.push({field: 'type', label: 'Type', sortable: true});
         }
 
         extra_attributes = mp.prefs.get('extra_attributes').trim();
         if (extra_attributes !== "") {
             extra_attributes = extra_attributes.split(new RegExp(',\\s*'));
             for (i = 0; i < extra_attributes.length; i++) {
-                fields.push({label: extra_attributes[i], field: [extra_attributes[i], 'value'], sortable: true});
+                fields.push({label: extra_attributes[i], sort_id: extra_attributes[i], field: [extra_attributes[i], 'value'], sortable: true});
             }
         }
 


### PR DESCRIPTION
This pull request add support for ordering entities by id or type. This requires support from the context broker, so you should connect to a orion context broker v0.12.0 or higher, for example.